### PR TITLE
feat: 오너먼트 배치 시 겹침 검사

### DIFF
--- a/src/main/java/site/treetory/domain/tree/enums/Size.java
+++ b/src/main/java/site/treetory/domain/tree/enums/Size.java
@@ -12,14 +12,26 @@ public enum Size {
     ;
 
     private final Integer radius;
-    
+
     public static String getSize(Integer messageLength) {
-        // TODO: 메시지 길이에 따른 사이즈 string 반환
-        return "SMALL";
+
+        if (messageLength < 100) {
+            return "SMALL";
+        } else if (messageLength < 200) {
+            return "MEDIUM";
+        } else {
+            return "LARGE";
+        }
     }
 
-    public static Integer getRadius(Integer messageLength) {
-        // TODO: 메시지 길이에 따른 반지름 반환
-        return 1;
+    public static int getRadius(Integer messageLength) {
+
+        if (messageLength < 100) {
+            return 22;
+        } else if (messageLength < 200) {
+            return 30;
+        } else {
+            return 38;
+        }
     }
 }

--- a/src/main/java/site/treetory/domain/tree/service/TreeService.java
+++ b/src/main/java/site/treetory/domain/tree/service/TreeService.java
@@ -15,6 +15,7 @@ import site.treetory.domain.tree.entity.PlacedOrnament;
 import site.treetory.domain.tree.entity.Tree;
 import site.treetory.domain.tree.enums.Background;
 import site.treetory.domain.tree.enums.Font;
+import site.treetory.domain.tree.enums.Size;
 import site.treetory.domain.tree.enums.Theme;
 import site.treetory.domain.tree.repository.OrnamentRepository;
 import site.treetory.domain.tree.repository.PlacedOrnamentRepository;
@@ -64,6 +65,8 @@ public class TreeService {
         Ornament ornament = ornamentRepository.findById(req.getOrnamentId())
                 .orElseThrow(() -> new CustomException(NOT_FOUND));
 
+        List<PlacedOrnament> placedOrnaments = placedOrnamentRepository.findAllByTreeId(tree.getId());
+
         PlacedOrnament placedOrnament = PlacedOrnament.builder()
                 .tree(tree)
                 .ornament(ornament)
@@ -74,7 +77,35 @@ public class TreeService {
                 .font(Font.getFont(req.getFont()))
                 .build();
 
+        if (checkIntersection(placedOrnament, placedOrnaments)) {
+            throw new CustomException(BAD_REQUEST);
+        }
+
         placedOrnamentRepository.save(placedOrnament);
+    }
+
+    private boolean checkIntersection(PlacedOrnament placedOrnament, List<PlacedOrnament> placedOrnaments) {
+
+        for (PlacedOrnament ornament : placedOrnaments) {
+            if (checkIntersection(ornament, placedOrnament)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean checkIntersection(PlacedOrnament o1, PlacedOrnament o2) {
+
+        int dx = o1.getPositionX() - o2.getPositionX();
+        int dy = o1.getPositionY() - o2.getPositionY();
+
+        int r1 = Size.getRadius(o1.getMessage().length());
+        int r2 = Size.getRadius(o2.getMessage().length());
+        int radSum = r1 + r2;
+
+        return dx * dx + dy * dy < radSum * radSum;
+
     }
 
     @Transactional

--- a/src/test/java/site/treetory/domain/tree/controller/TreeControllerTest.java
+++ b/src/test/java/site/treetory/domain/tree/controller/TreeControllerTest.java
@@ -263,8 +263,8 @@ public class TreeControllerTest {
         jsonObject.put("ornamentId", "1");
         jsonObject.put("nickname", "테스트방문자");
         jsonObject.put("message", "너를처음본순간부터좋아했어방학전에고백하고싶었는데바보같이그땐용기가없더라지금은이수많은사람들앞에서오로지너만사랑한다고말하고싶어서큰마음먹고용기내어봐매일매일버스에서너볼때마다두근댔고동아리랑과활동에서도너만보이고너생각만나고지난3월부터계속그랬어니가남자친구랑헤어지고니맘이아파울때내마음도너무아팠지만내심좋은맘두있었어이런내맘을어떻게말할지고민하다가정말인생에서제일크게용기내어세상에서제일멋지게많은사람들앞에서너한테고백해주고싶었어나만의태양이되어줄래?난너의달님이될게내일3시반에너수업마치고학관앞에서기다리고있을게");
-        jsonObject.put("positionX", "10");
-        jsonObject.put("positionY", "10");
+        jsonObject.put("positionX", "100");
+        jsonObject.put("positionY", "100");
         jsonObject.put("font", "NANUM_PEN");
         
         // when
@@ -309,8 +309,8 @@ public class TreeControllerTest {
         jsonObject.put("ornamentId", "1");
         jsonObject.put("nickname", "테스트방문자");
         jsonObject.put("message", "너를처음본순간부터좋아했어방학전에고백하고싶었는데바보같이그땐용기가없더라지금은이수많은사람들앞에서오로지너만사랑한다고말하고싶어서큰마음먹고용기내어봐매일매일버스에서너볼때마다두근댔고동아리랑과활동에서도너만보이고너생각만나고지난3월부터계속그랬어니가남자친구랑헤어지고니맘이아파울때내마음도너무아팠지만내심좋은맘두있었어이런내맘을어떻게말할지고민하다가정말인생에서제일크게용기내어세상에서제일멋지게많은사람들앞에서너한테고백해주고싶었어나만의태양이되어줄래?난너의달님이될게내일3시반에너수업마치고학관앞에서기다리고있을게");
-        jsonObject.put("positionX", "10");
-        jsonObject.put("positionY", "10");
+        jsonObject.put("positionX", "100");
+        jsonObject.put("positionY", "100");
         jsonObject.put("font", "NANUM_PEN");
 
         // when
@@ -355,8 +355,8 @@ public class TreeControllerTest {
         jsonObject.put("ornamentId", "999");
         jsonObject.put("nickname", "테스트방문자");
         jsonObject.put("message", "너를처음본순간부터좋아했어방학전에고백하고싶었는데바보같이그땐용기가없더라지금은이수많은사람들앞에서오로지너만사랑한다고말하고싶어서큰마음먹고용기내어봐매일매일버스에서너볼때마다두근댔고동아리랑과활동에서도너만보이고너생각만나고지난3월부터계속그랬어니가남자친구랑헤어지고니맘이아파울때내마음도너무아팠지만내심좋은맘두있었어이런내맘을어떻게말할지고민하다가정말인생에서제일크게용기내어세상에서제일멋지게많은사람들앞에서너한테고백해주고싶었어나만의태양이되어줄래?난너의달님이될게내일3시반에너수업마치고학관앞에서기다리고있을게");
-        jsonObject.put("positionX", "10");
-        jsonObject.put("positionY", "10");
+        jsonObject.put("positionX", "100");
+        jsonObject.put("positionY", "100");
         jsonObject.put("font", "NANUM_PEN");
 
         // when
@@ -401,8 +401,8 @@ public class TreeControllerTest {
         jsonObject.put("ornamentId", "1");
         jsonObject.put("nickname", "테스트방문자");
         jsonObject.put("message", "너를처음본순간부터좋아했어방학전에고백하고싶었는데바보같이그땐용기가없더라지금은이수많은사람들앞에서오로지너만사랑한다고말하고싶어서큰마음먹고용기내어봐매일매일버스에서너볼때마다두근댔고동아리랑과활동에서도너만보이고너생각만나고지난3월부터계속그랬어니가남자친구랑헤어지고니맘이아파울때내마음도너무아팠지만내심좋은맘두있었어이런내맘을어떻게말할지고민하다가정말인생에서제일크게용기내어세상에서제일멋지게많은사람들앞에서너한테고백해주고싶었어나만의태양이되어줄래?난너의달님이될게내일3시반에너수업마치고학관앞에서기다리고있을게");
-        jsonObject.put("positionX", "10");
-        jsonObject.put("positionY", "10");
+        jsonObject.put("positionX", "100");
+        jsonObject.put("positionY", "100");
         jsonObject.put("font", "NANUM_PENS");
 
         // when
@@ -447,8 +447,8 @@ public class TreeControllerTest {
         jsonObject.put("ornamentId", "1");
         jsonObject.put("nickname", "테스트방문자");
         jsonObject.put("message", "어려분 단체방에 죄송하지만 글 하나만 젇겠습니다.너를처음본순간부터좋아했어방학전에고백하고싶었는데바보같이그땐용기가없더라지금은이수많은사람들앞에서오로지너만사랑한다고말하고싶어서큰마음먹고용기내어봐매일매일버스에서너볼때마다두근댔고동아리랑과활동에서도너만보이고너생각만나고지난3월부터계속그랬어니가남자친구랑헤어지고니맘이아파울때내마음도너무아팠지만내심좋은맘두있었어이런내맘을어떻게말할지고민하다가정말인생에서제일크게용기내어세상에서제일멋지게많은사람들앞에서너한테고백해주고싶었어나만의태양이되어줄래?난너의달님이될게내일3시반에너수업마치고학관앞에서기다리고있을게.이제 누가 공지해주냐");
-        jsonObject.put("positionX", "10");
-        jsonObject.put("positionY", "10");
+        jsonObject.put("positionX", "100");
+        jsonObject.put("positionY", "100");
         jsonObject.put("font", "NANUM_PEN");
 
         // when
@@ -492,8 +492,8 @@ public class TreeControllerTest {
         jsonObject.put("ornamentId", "1");
         jsonObject.put("nickname", "テスト訪問者");
         jsonObject.put("message", "너를처음본순간부터좋아했어방학전에고백하고싶었는데바보같이그땐용기가없더라지금은이수많은사람들앞에서오로지너만사랑한다고말하고싶어서큰마음먹고용기내어봐매일매일버스에서너볼때마다두근댔고동아리랑과활동에서도너만보이고너생각만나고지난3월부터계속그랬어니가남자친구랑헤어지고니맘이아파울때내마음도너무아팠지만내심좋은맘두있었어이런내맘을어떻게말할지고민하다가정말인생에서제일크게용기내어세상에서제일멋지게많은사람들앞에서너한테고백해주고싶었어나만의태양이되어줄래?난너의달님이될게내일3시반에너수업마치고학관앞에서기다리고있을게");
-        jsonObject.put("positionX", "10");
-        jsonObject.put("positionY", "10");
+        jsonObject.put("positionX", "100");
+        jsonObject.put("positionY", "100");
         jsonObject.put("font", "NANUM_PEN");
 
         // when
@@ -522,6 +522,51 @@ public class TreeControllerTest {
                                         )
                                 )
                                 .requestSchema(Schema.schema("오너먼트 배치 Request"))
+                                .build()
+                        ))
+                );
+    }
+
+    @Test
+    @DisplayName("오너먼트 배치 실패 - 겹침")
+    public void place_ornament_fail_intersection() throws Exception {
+
+        // given
+        String uuid = "b8a3eb59-b956-4df9-8a55-80784016b8d4";
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("ornamentId", "1");
+        jsonObject.put("nickname", "테스트방문자");
+        jsonObject.put("message", "너를처음본순간부터좋아했어방학전에고백하고싶었는데바보같이그땐용기가없더라지금은이수많은사람들앞에서오로지너만사랑한다고말하고싶어서큰마음먹고용기내어봐매일매일버스에서너볼때마다두근댔고동아리랑과활동에서도너만보이고너생각만나고지난3월부터계속그랬어니가남자친구랑헤어지고니맘이아파울때내마음도너무아팠지만내심좋은맘두있었어이런내맘을어떻게말할지고민하다가정말인생에서제일크게용기내어세상에서제일멋지게많은사람들앞에서너한테고백해주고싶었어나만의태양이되어줄래?난너의달님이될게내일3시반에너수업마치고학관앞에서기다리고있을게");
+        jsonObject.put("positionX", "1");
+        jsonObject.put("positionY", "1");
+        jsonObject.put("font", "NANUM_PEN");
+
+        // when
+        ResultActions actions = mockMvc.perform(
+                post("/api/trees/{uuid}/ornaments", uuid)
+                        .accept(APPLICATION_JSON)
+                        .contentType(APPLICATION_JSON)
+                        .content(jsonObject.toString())
+                        .characterEncoding("UTF-8")
+        );
+
+        // then
+        actions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.header.message").value(BAD_REQUEST.getMessage()))
+                .andDo(document(
+                        "오너먼트 배치 실패 - 겹침",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Tree API")
+                                .summary("오너먼트 배치 API")
+                                .responseFields(
+                                        getCommonResponseFields(
+                                                fieldWithPath("body").type(NULL)
+                                                        .description("내용 없음")
+                                        )
+                                )
                                 .build()
                         ))
                 );


### PR DESCRIPTION
### PR Type
<!-- Please check the one that applies to this PR using "x".-->
- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [x] 테스트 코드 작성(Test)
- [ ] Other… Please describe:

### 요약(Summary)
오너먼트 배치 시 겹침 검사

### 상세 내용(Describe your changes)
- 메시지 길이에 따라 오너먼트의 사이즈 및 반지름 길이를 반환하는 메서드 구현
- 새로운 오너먼트를 배치할 때, 기존의 오너먼트들과 겹치는지 검사 시행
- 테스트 코드 추가

### Issue Number or Link
<!--
- Fixes: 이슈 수정중 (아직 해결되지 않은 경우)
- Resolves: 이슈를 해결했을 때 사용
- Ref: 참고할 이슈가 있을 때 사용
- Related to: 해당 커밋에 관련된 이슈번호 (아직 해결되지 않은 경우)
ex) Resolves: #4
-->
Resolves: #44 
